### PR TITLE
update mist.ini

### DIFF
--- a/cores/fpgagen/mist.ini
+++ b/cores/fpgagen/mist.ini
@@ -9,4 +9,5 @@ joy_key_map=1000,E2
 joy_key_map=2000,E6
 joy_key_map=4,51
 joy_key_map=8,52
+joystick_remap=0810,E501,1,2,4,8,10,20,40,10,20,40,0,0,80,80 ;Hyperkin "GN6" USB Genisis/Megadrive (6 buttons mapped as ABC twice). No 6 button support yet?
 


### PR DESCRIPTION
including the Hyperkin GN6 contoller (USB Megadrive clone)